### PR TITLE
Correction publication des zones et mode ECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Avant le flash :
 
 #### 🔹 Module Connect
 1. Sur la chaudière : **lancer l’association Connect**  
+  a. Accédez au menu de configuration
+  b. aller dans "partenaire" puis sur "Ajouter"
+  c. Lancez l'association Frisquet Connect. Appuyez sur OK jusqu’à ce que l’écran demande d’associer la Frisquet Connect.
 2. Sur le portail ou Home Assistant : activer le bouton **“Associer Connect”**
 3. Une fois reconnu, la chaudière commencera à envoyer les données vers le module
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -63,6 +63,9 @@ void Config::load() {
   _useSatelliteVirtualZ1 = _preferences.getBool("useSatVirtuelZ1", false);
   _useSatelliteVirtualZ2 = _preferences.getBool("useSatVirtuelZ2", false);
   _useSatelliteVirtualZ3 = _preferences.getBool("useSatVirtuelZ3", false);
+  _useZone1 = _preferences.getBool("useZone1", true);
+  _useZone2 = _preferences.getBool("useZone2", false);
+  _useZone3 = _preferences.getBool("useZone3", false);
 
   _preferences.end();
   delay(100);
@@ -121,6 +124,9 @@ void Config::save() {
   _preferences.putBool("useSatVirtuelZ1", _useSatelliteVirtualZ1);
   _preferences.putBool("useSatVirtuelZ2", _useSatelliteVirtualZ2);
   _preferences.putBool("useSatVirtuelZ3", _useSatelliteVirtualZ3);
+  _preferences.putBool("useZone1", _useZone1);
+  _preferences.putBool("useZone2", _useZone2);
+  _preferences.putBool("useZone3", _useZone3);
 
   _preferences.end();
 }

--- a/src/Config.h
+++ b/src/Config.h
@@ -22,6 +22,9 @@ class Config {
         bool _useSatelliteVirtualZ1 = false;
         bool _useSatelliteVirtualZ2 = false;
         bool _useSatelliteVirtualZ3 = false;
+        bool _useZone1 = true;
+        bool _useZone2 = false;
+        bool _useZone3 = false;
     public:
         Config();
         void load();
@@ -50,4 +53,10 @@ class Config {
         void useSatelliteVirtualZ2(bool useSatelliteVirtualZ2) { _useSatelliteVirtualZ2 = useSatelliteVirtualZ2; }
         bool useSatelliteVirtualZ3() { return _useSatelliteVirtualZ3; };
         void useSatelliteVirtualZ3(bool useSatelliteVirtualZ3) { _useSatelliteVirtualZ3 = useSatelliteVirtualZ3; }
+        bool useZone1() { return _useZone1; }
+        bool useZone1(bool useZone1) { _useZone1 = useZone1; return _useZone1; }
+        bool useZone2() { return _useZone2; }
+        bool useZone2(bool useZone2) { _useZone2 = useZone2; return _useZone2; }
+        bool useZone3() { return _useZone3; }
+        bool useZone3(bool useZone3) { _useZone3 = useZone3; return _useZone3; }
 };

--- a/src/Frisquet/Connect.cpp
+++ b/src/Frisquet/Connect.cpp
@@ -191,7 +191,6 @@ bool Connect::recupererTemperatures() {
         setTemperatureExterieure(buff.temperatureExterieure.toFloat());
         setTemperatureECS(buff.temperatureECS.toFloat());
         setTemperatureCDC(buff.temperatureCDC.toFloat());
-        
         return true;
     } while(retry++ < 1);
 
@@ -654,14 +653,14 @@ void Connect::loop() {
         }
 
         if (now - _lastEnvoiZone >= 30000 || _lastEnvoiZone == 0) { // 30 secondes
-            envoiZone();
+            envoiZones();
         }
     }
 }
 
-void Connect::envoiZone() {
+void Connect::envoiZones() {
     if(estAssocie()) {
-        if(getZone1().getSource() == Zone::SOURCE::CONNECT && _zone1.getLastChange() > _zone1.getLastEnvoi()) {
+        if(getConfig().useZone1() && getZone1().getSource() == Zone::SOURCE::CONNECT && _zone1.getLastChange() > _zone1.getLastEnvoi()) {
             info("[CONNECT] Envoi de la zone 1.");
             if(envoyerZone(_zone1)) {
                 info("[CONNECT] Envoi réussi !");
@@ -670,7 +669,7 @@ void Connect::envoiZone() {
                 _envoiZ1 = false;
             }
         }
-        if(getZone2().getSource() == Zone::SOURCE::CONNECT && _zone2.getLastChange() > _zone2.getLastEnvoi()) {
+        if(getConfig().useZone2() && getZone2().getSource() == Zone::SOURCE::CONNECT && _zone2.getLastChange() > _zone2.getLastEnvoi()) {
             info("[CONNECT] Envoi de la zone 2 (id=%d numero=%d).", _zone2.getIdZone(), _zone2.getNumeroZone());
             if(envoyerZone(_zone2)) {
                 info("[CONNECT] Envoi réussi !");
@@ -679,7 +678,7 @@ void Connect::envoiZone() {
                 _envoiZ2 = false;
             }
         }
-        if(getZone3().getSource() == Zone::SOURCE::CONNECT && _zone3.getLastChange() > _zone3.getLastEnvoi()) {
+        if(getConfig().useZone3() && getZone3().getSource() == Zone::SOURCE::CONNECT && _zone3.getLastChange() > _zone3.getLastEnvoi()) {
             info("[CONNECT] Envoi de la zone 3 (id=%d numero=%d).", _zone3.getIdZone(), _zone3.getNumeroZone());
             if(envoyerZone(_zone3)) {
                 info("[CONNECT] Envoi réussi !");

--- a/src/Frisquet/Connect.cpp
+++ b/src/Frisquet/Connect.cpp
@@ -471,8 +471,7 @@ bool Connect::onReceive(byte* donnees, size_t length) {
             if(readBuffer.remainingLength() < sizeof(donneesZone)) { return false; }
             readBuffer.getBytes((byte*)&donneesZone, sizeof(donneesZone));
 
-            // Le champ `idReception` peut contenir le bit 0x80 (ACK). Masque-le
-            // pour obtenir l'ID de zone réel avant d'indexer les zones.
+            // Le champ `idReception` peut contenir le bit 0x80 (ACK) : Ajout d'un masque
             uint8_t zoneId = header.idReception & 0x7F;
             
             if(getZone(zoneId).getNumeroZone() == 0) {
@@ -490,7 +489,8 @@ bool Connect::onReceive(byte* donnees, size_t length) {
                 getZone(zoneId).setTemperatureConfort(donneesZone.temperatureConfort.toFloat());
             }
 
-            saveConfig();
+            //Sauvegarde de la conf de la zone en NVs
+            getZone(zoneId).saveConfig();
             info("[CONNECT] Mise à jour zone %d (id %d), publication MQTT locale.", getZone(zoneId).getNumeroZone(), zoneId );
             getZone(zoneId).publishMqtt();
 

--- a/src/Frisquet/Connect.h
+++ b/src/Frisquet/Connect.h
@@ -84,7 +84,7 @@ class Connect : public FrisquetDevice {
         void setConsommationECS(int16_t consommation);
         void setConsommationChauffage(int16_t consommation);
 
-        void envoiZone();
+        void envoiZones();
 
         bool _envoiZ1 = false;
         bool _envoiZ2 = false;

--- a/src/Frisquet/Connect.h
+++ b/src/Frisquet/Connect.h
@@ -20,7 +20,7 @@ class Connect : public FrisquetDevice {
         void loop();
 
          enum MODE_ECS : uint8_t {
-                    INCONNU = 0XFF,
+            INCONNU = 0XFF,
             STOP = 0x29,
             MAX = 0x01,
             ECO = 0x09,

--- a/src/Frisquet/FrisquetDevice.cpp
+++ b/src/Frisquet/FrisquetDevice.cpp
@@ -34,7 +34,7 @@ bool FrisquetDevice::associer(NetworkID& networkId, uint8_t& idAssociation) {
         readBuffer.getBytes((byte*)&donnees, sizeof(donnees));
 
         if(donnees.header.idExpediteur == ID_CHAUDIERE && donnees.header.type == FrisquetRadio::MessageType::ASSOCIATION) {
-            info("[DEVICE] Récéption trame d'association");
+            info("[DEVICE] Réception trame d'association");
 
             struct {
                 FrisquetRadio::RadioTrameHeader header;

--- a/src/Frisquet/FrisquetRadio.h
+++ b/src/Frisquet/FrisquetRadio.h
@@ -17,7 +17,7 @@ class FrisquetRadio : public Radio {
         byte idExpediteur = 0x00;
         byte idAssociation = 0x00;
         byte idMessage = 0x00;
-        byte idReception = 0x01; //0x01 => Si message direct, sinon id destinataire finale (exemple envoi au satellite Z1 via chaudière) + 0x80 si accusé récéption
+        byte idReception = 0x01; //0x01 => Si message direct, sinon id destinataire finale (exemple envoi au satellite Z1 via chaudière) + 0x80 si accusé réception
         byte type = 0x00;
 
         void answer(RadioTrameHeader& radioTrameHeader) {

--- a/src/Frisquet/Satellite.cpp
+++ b/src/Frisquet/Satellite.cpp
@@ -377,7 +377,7 @@ bool Satellite::onReceive(byte* donnees, size_t length) {
 
     //info("[SATELLITE Z] Interception envoi consigne.", header->type);
     if(!_modeVirtuel) {
-        if(length == 23 && header->type == FrisquetRadio::MessageType::INIT && header->idExpediteur == this->getId() && header->idMessage != getIdMessage()) { // Récéption en écoute
+        if(length == 23 && header->type == FrisquetRadio::MessageType::INIT && header->idExpediteur == this->getId() && header->idMessage != getIdMessage()) { // Réception en écoute
             FrisquetRadio::RadioTrameInit* requete = (FrisquetRadio::RadioTrameInit*) readBuffer.getBytes(sizeof(FrisquetRadio::RadioTrameInit));
             if(requete->adresseMemoireEcriture.toUInt16() == 0xA02F && requete->tailleMemoireEcriture.toUInt16() == 0x0004) { // Envoi consigne
 

--- a/src/Frisquet/Zone.cpp
+++ b/src/Frisquet/Zone.cpp
@@ -6,7 +6,7 @@ void Zone::loadConfig() {
 
     _preferences.begin("zoneCfg" + getNumeroZone(), false);
 
-    setMode((Zone::MODE_ZONE)_preferences.getUChar("mode"));
+    setMode((Zone::MODE_ZONE)_preferences.getUChar("mode", (uint8_t)Zone::MODE_ZONE::INCONNU));
     setModeOptions(_preferences.getUChar("modeOpts"));
     setTemperatureConfort(_preferences.getFloat("tempConfort"));
     setTemperatureReduit(_preferences.getFloat("tempReduit"));

--- a/src/FrisquetManager.cpp
+++ b/src/FrisquetManager.cpp
@@ -14,39 +14,36 @@ void FrisquetManager::begin()
 
     initMqtt();
 
-    if(_cfg.useSatelliteVirtualZ1()) {
-        _zone1.setSource(Zone::SOURCE::SATELLITE_VIRTUEL);
-    } else if(_cfg.useConnect()) {
-        _zone1.setSource(Zone::SOURCE::CONNECT);
-    } else {
-        _zone1.setSource(Zone::SOURCE::SATELLITE_PHYSIQUE);
-    }
     if (_cfg.useZone1()) {
+        if(_cfg.useSatelliteVirtualZ1()) {
+            _zone1.setSource(Zone::SOURCE::SATELLITE_VIRTUEL);
+        } else if(_cfg.useConnect()) {
+            _zone1.setSource(Zone::SOURCE::CONNECT);
+        } else {
+            _zone1.setSource(Zone::SOURCE::SATELLITE_PHYSIQUE);
+        }
         _zone1.begin();
     }
     
-    if(_cfg.useSatelliteVirtualZ2()) {
-        _zone2.setSource(Zone::SOURCE::SATELLITE_VIRTUEL);
-    } else if(_cfg.useConnect()) {
-        _zone2.setSource(Zone::SOURCE::CONNECT);
-    } else {
-        _zone2.setSource(Zone::SOURCE::SATELLITE_PHYSIQUE);
-    }
-    // Enregistrer la zone 2 si l'utilisateur a déclaré qu'elle est présente.
-    // (Les satellites restent gérés séparément par useSatelliteZ2/useSatelliteVirtualZ2)
     if (_cfg.useZone2()) {
+        if(_cfg.useSatelliteVirtualZ2()) {
+            _zone2.setSource(Zone::SOURCE::SATELLITE_VIRTUEL);
+        } else if(_cfg.useConnect()) {
+            _zone2.setSource(Zone::SOURCE::CONNECT);
+        } else {
+            _zone2.setSource(Zone::SOURCE::SATELLITE_PHYSIQUE);
+        }
         _zone2.begin();
     }
 
-    if(_cfg.useSatelliteVirtualZ3()) {
-        _zone3.setSource(Zone::SOURCE::SATELLITE_VIRTUEL);
-    } else if(_cfg.useConnect()) {
-        _zone3.setSource(Zone::SOURCE::CONNECT);
-    } else {
-        _zone3.setSource(Zone::SOURCE::SATELLITE_PHYSIQUE);
-    }
-    // Enregistrer la zone 3 si l'utilisateur a déclaré qu'elle est présente.
     if (_cfg.useZone3()) {
+        if(_cfg.useSatelliteVirtualZ3()) {
+            _zone3.setSource(Zone::SOURCE::SATELLITE_VIRTUEL);
+        } else if(_cfg.useConnect()) {
+            _zone3.setSource(Zone::SOURCE::CONNECT);
+        } else {
+            _zone3.setSource(Zone::SOURCE::SATELLITE_PHYSIQUE);
+        }
         _zone3.begin();
     }
 

--- a/src/FrisquetManager.cpp
+++ b/src/FrisquetManager.cpp
@@ -21,7 +21,9 @@ void FrisquetManager::begin()
     } else {
         _zone1.setSource(Zone::SOURCE::SATELLITE_PHYSIQUE);
     }
-    _zone1.begin();
+    if (_cfg.useZone1()) {
+        _zone1.begin();
+    }
     
     if(_cfg.useSatelliteVirtualZ2()) {
         _zone2.setSource(Zone::SOURCE::SATELLITE_VIRTUEL);
@@ -30,7 +32,11 @@ void FrisquetManager::begin()
     } else {
         _zone2.setSource(Zone::SOURCE::SATELLITE_PHYSIQUE);
     }
-    _zone2.begin();
+    // Enregistrer la zone 2 si l'utilisateur a déclaré qu'elle est présente.
+    // (Les satellites restent gérés séparément par useSatelliteZ2/useSatelliteVirtualZ2)
+    if (_cfg.useZone2()) {
+        _zone2.begin();
+    }
 
     if(_cfg.useSatelliteVirtualZ3()) {
         _zone3.setSource(Zone::SOURCE::SATELLITE_VIRTUEL);
@@ -39,7 +45,10 @@ void FrisquetManager::begin()
     } else {
         _zone3.setSource(Zone::SOURCE::SATELLITE_PHYSIQUE);
     }
-    _zone3.begin();
+    // Enregistrer la zone 3 si l'utilisateur a déclaré qu'elle est présente.
+    if (_cfg.useZone3()) {
+        _zone3.begin();
+    }
 
     if (_cfg.useConnect()) {
         _connect.begin();
@@ -54,13 +63,13 @@ void FrisquetManager::begin()
             initDS18B20();
         }
     }
-    if (_cfg.useSatelliteZ1()) {
+    if (_cfg.useZone1() && _cfg.useSatelliteZ1()) {
         _satelliteZ1.begin(_cfg.useSatelliteVirtualZ1());
     }
-    if (_cfg.useSatelliteZ2()) {
+    if (_cfg.useZone2() && _cfg.useSatelliteZ2()) {
         _satelliteZ2.begin(_cfg.useSatelliteVirtualZ2());
     }
-    if (_cfg.useSatelliteZ3()) {
+    if (_cfg.useZone3() && _cfg.useSatelliteZ3()) {
         _satelliteZ3.begin(_cfg.useSatelliteVirtualZ3());
     }
 
@@ -78,7 +87,7 @@ void FrisquetManager::loop()
 {
     uint32_t now = millis();
 
-    if (FrisquetRadio::receivedFlag) { // Récéption données radio
+    if (FrisquetRadio::receivedFlag) { // Réception données radio
         onRadioReceive();
     }
 
@@ -92,6 +101,12 @@ void FrisquetManager::loop()
     
     if (_cfg.useSatelliteZ1()) {
         _satelliteZ1.loop();
+    }
+    if (_cfg.useSatelliteZ2()) {
+        _satelliteZ2.loop();
+    }
+    if (_cfg.useSatelliteZ3()) {
+        _satelliteZ3.loop();
     }
 }
 

--- a/src/Portal.cpp
+++ b/src/Portal.cpp
@@ -199,6 +199,13 @@ void Portal::handleGetConfig() {
           String(_frisquetManager.config().useSondeExterieure() ? "true" : "false") + ",";
   json += "\"useDS18B20\":" +
           String(_frisquetManager.config().useDS18B20() ? "true" : "false") + ",";
+    // Zones présentes
+    json += "\"useZone1\":" +
+      String(_frisquetManager.config().useZone1() ? "true" : "false") + ",";
+    json += "\"useZone2\":" +
+      String(_frisquetManager.config().useZone2() ? "true" : "false") + ",";
+    json += "\"useZone3\":" +
+      String(_frisquetManager.config().useZone3() ? "true" : "false") + ",";
    
   // Satellites physiques
   json += "\"useSatelliteZ1\":" +
@@ -271,6 +278,21 @@ void Portal::handlePostConfig() {
     bool v = parseBoolArg(_srv.arg("useDS18B20"), cur);
     _frisquetManager.config().useDS18B20(v);
   }
+    if (_srv.hasArg("useZone1")) {
+      bool cur = _frisquetManager.config().useZone1();
+      bool v = parseBoolArg(_srv.arg("useZone1"), cur);
+      _frisquetManager.config().useZone1(v);
+    }
+    if (_srv.hasArg("useZone2")) {
+      bool cur = _frisquetManager.config().useZone2();
+      bool v = parseBoolArg(_srv.arg("useZone2"), cur);
+      _frisquetManager.config().useZone2(v);
+    }
+    if (_srv.hasArg("useZone3")) {
+      bool cur = _frisquetManager.config().useZone3();
+      bool v = parseBoolArg(_srv.arg("useZone3"), cur);
+      _frisquetManager.config().useZone3(v);
+    }
 
   if (_srv.hasArg("useSatelliteZ1")) {
     bool cur = _frisquetManager.config().useSatelliteZ1();
@@ -1188,6 +1210,29 @@ String Portal::html() {
               </label>
               <div class='hint'>Active l'utilisation d'un capteur de température filaire.</div>
             </div>
+          </div>
+          <div class='grid-3' style='margin-top:8px'>
+            <div class='row'>
+              <label class='check-row'>
+                <input id='useZone1' type='checkbox'>
+                <span>Zone 1 présente</span>
+              </label>
+              <div class='hint'>Zone 1 physique présente.</div>
+            </div>
+            <div class='row'>
+              <label class='check-row'>
+                <input id='useZone2' type='checkbox'>
+                <span>Zone 2 présente</span>
+              </label>
+              <div class='hint'>Zone 2 physique présente.</div>
+            </div>
+            <div class='row'>
+              <label class='check-row'>
+                <input id='useZone3' type='checkbox'>
+                <span>Zone 3 présente</span>
+              </label>
+              <div class='hint'>Zone 3 physique présente.</div>
+            </div>
             <div class='row'>
               <button type='button' class='btn btn-sm' id='btnPairSondeExt' style='margin-top:6px;display:none'>
                 Associer la sonde extérieure
@@ -1326,6 +1371,7 @@ const FIELDS = [
   "mqttHost","mqttPort","mqttUser","mqttPass",
   "mqttClientId","mqttBaseTopic",
   "networkID","useConnect","useSondeExt","useDS18B20",
+  "useZone1","useZone2","useZone3",
   "useSatelliteZ1","useSatelliteZ2","useSatelliteZ3",
   "useSatelliteVirtualZ1","useSatelliteVirtualZ2","useSatelliteVirtualZ3"
 ];
@@ -1360,6 +1406,14 @@ function updatePairButtons() {
   if (chkZ3 && btnZ3) {
     btnZ3.style.display = chkZ3.checked ? "inline-flex" : "none";
   }
+
+  // Pair buttons visibility should also consider whether the corresponding zone is present
+  const chkZone1 = $("#useZone1");
+  const chkZone2 = $("#useZone2");
+  const chkZone3 = $("#useZone3");
+  if (btnZ1 && chkZone1) btnZ1.style.display = (chkZ1.checked && chkZone1.checked) ? "inline-flex" : "none";
+  if (btnZ2 && chkZone2) btnZ2.style.display = (chkZ2.checked && chkZone2.checked) ? "inline-flex" : "none";
+  if (btnZ3 && chkZone3) btnZ3.style.display = (chkZ3.checked && chkZone3.checked) ? "inline-flex" : "none";
 }
 
 
@@ -1565,12 +1619,18 @@ document.addEventListener("DOMContentLoaded", ()=>{
   const chkZ1      = $("#useSatelliteZ1");
   const chkZ2      = $("#useSatelliteZ2");
   const chkZ3      = $("#useSatelliteZ3");
+  const chkZone1   = $("#useZone1");
+  const chkZone2   = $("#useZone2");
+  const chkZone3   = $("#useZone3");
 
   if (chkConnect) chkConnect.addEventListener("change", updatePairButtons);
   if (chkSonde)   chkSonde.addEventListener("change", updatePairButtons);
   if (chkZ1)      chkZ1.addEventListener("change", updatePairButtons);
   if (chkZ2)      chkZ2.addEventListener("change", updatePairButtons);
   if (chkZ3)      chkZ3.addEventListener("change", updatePairButtons);
+  if (chkZone1)   chkZone1.addEventListener("change", updatePairButtons);
+  if (chkZone2)   chkZone2.addEventListener("change", updatePairButtons);
+  if (chkZone3)   chkZone3.addEventListener("change", updatePairButtons);
 
   const btnPairConnect = $("#btnPairConnect");
   const btnPairSonde   = $("#btnPairSondeExt");


### PR DESCRIPTION
Ajout de 3 nouveaux paramètres pour indiquer quelles sont les zones installées sur la chaudière pour ne pousser la config que de ces zones là.

Correction de l'id utilisé (idReception vs idExpediteur) pour la récupération de la zone provoquant un mélange des données zone1 et zone 2

Correction de la lecture du flag pour le modeECS (étonnant....). Sans cette modif modeECS = inconnu chez moi

Correction de la sauvegarde de la zone en NVs une fois mise à jour. Permet de republier les dernières valeurs reçues lors du redémarrage de l'ESP