### PR TITLE
Fix panic

### DIFF
--- a/src/Logs.h
+++ b/src/Logs.h
@@ -5,7 +5,7 @@
 
 class Logs {
 public:
-  static constexpr size_t kMaxLines = 500;
+  static constexpr size_t kMaxLines = 300;
   static constexpr size_t kMaxLevelLen = 8;
   static constexpr size_t kMaxMessageLen = 192;
   static constexpr size_t kMaxFormattedLen = 256;

--- a/src/MQTT/MqttDevice.h
+++ b/src/MQTT/MqttDevice.h
@@ -51,12 +51,15 @@ struct MqttDevice {
 
   MqttEntity* getEntity(String id) {
     auto it = entities.find(id);
-    
     if (it != entities.end()) {
       return it->second;
     }
-    
-    return new MqttEntity();
+
+    // Create, store and return a new entity to avoid leaking anonymous allocations
+    MqttEntity* e = new MqttEntity();
+    e->id = id;
+    entities[id] = e;
+    return e;
   }
 };
 

--- a/src/MQTT/MqttManager.h
+++ b/src/MQTT/MqttManager.h
@@ -109,12 +109,18 @@ public:
 
   MqttDevice* getDevice(String id) {
     auto it = _devices.find(id);
-    
     if (it != _devices.end()) {
       return it->second;
     }
-    
-    return new MqttDevice();
+
+    // If device is not registered yet, create it, set its id and baseTopic,
+    // store it in the map and return it. Prevents callers from receiving
+    // a heap allocation that isn't tracked (memory leak).
+    MqttDevice* d = new MqttDevice();
+    d->deviceId = id;
+    d->baseTopic = _opts.baseTopic;
+    _devices[id] = d;
+    return d;
   }
 
 private:


### PR DESCRIPTION
Réduction de la taille des logs en mémoire pour garder plus de place pour les objects dynamiques
Sauvegarde des deviceMqtt générée dans la map où elles sont recherchées (sinon elle sont tout le temps recréées)