### PR TITLE
Add support for Heltec WiFi LoRa 32 V4

### DIFF
--- a/boards/heltec_wifi_lora_32_V4.json
+++ b/boards/heltec_wifi_lora_32_V4.json
@@ -1,0 +1,55 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default_16MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DWIFI_LORA_32_V4",
+      "-DARDUINO_heltec_wifi_lora_32_V4",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DLoRaWAN_DEBUG_LEVEL=0",
+      "-DHELTEC_BOARD=30",
+      "-DSLOW_CLK_TPYE=0",
+      "-DMCU_ESP32_S3",
+      "-DHELTEC_WIFI_LORA_32_V4"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "heltec_wifi_lora_32_V4"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth",
+    "lora"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Heltec WiFi LoRa 32 (V4)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://heltec.org/project/wifi-lora-32-v4/",
+  "vendor": "Heltec"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,7 @@
 platform = espressif32 @ 7.0.0
 monitor_speed = 115200
 framework = arduino
+monitor_filters = esp32_exception_decoder
 
 lib_deps = 
 	jgromes/RadioLib@^6.6.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,17 +14,10 @@
 ; - upload_port = 192.168.1.185
 
 
-[env:heltec_wifi_lora_32_V3]
-platform = espressif32
-board = heltec_wifi_lora_32_V3
+[env]
+platform = espressif32 @ 7.0.0
 monitor_speed = 115200
 framework = arduino
-#upload_port = /dev/cu.usbserial-0001
-#monitor_port = /dev/cu.usbserial-0001
-upload_protocol = espota
-upload_port = 192.168.1.184
-
-upload_flags = "--host_port=3232"
 
 lib_deps = 
 	jgromes/RadioLib@^6.6.0
@@ -36,3 +29,12 @@ lib_deps =
 	bblanchon/ArduinoJson
 
 #extra_scripts = pre:tools/version.py
+
+
+[env:heltec_wifi_lora_32_V3]
+board = heltec_wifi_lora_32_V3
+#upload_port = /dev/cu.usbserial-0001
+#monitor_port = /dev/cu.usbserial-0001
+upload_protocol = espota
+upload_port = 192.168.1.184
+upload_flags = "--host_port=3232"

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,10 @@
 ; - upload_port = 192.168.1.185
 
 
+[platformio]
+default_envs = heltec_wifi_lora_32_V3
+
+
 [env]
 platform = espressif32 @ 7.0.0
 monitor_speed = 115200
@@ -36,6 +40,32 @@ lib_deps =
 board = heltec_wifi_lora_32_V3
 #upload_port = /dev/cu.usbserial-0001
 #monitor_port = /dev/cu.usbserial-0001
+upload_protocol = espota
+upload_port = 192.168.1.184
+upload_flags = "--host_port=3232"
+
+
+[env:heltec_wifi_lora_32_V4]
+board = heltec_wifi_lora_32_V4
+board_build.variants_dir = variants
+board_build.variant = heltec_V4
+# No automatic Reset when connecting via monitor
+monitor_dtr = 1
+monitor_rts = 1
+
+build_flags =
+	-DCORE_DEBUG_LEVEL=1
+#	-DBOARD_HAS_PSRAM
+#	-mfix-esp32-psram-cache-issue
+
+board_build.usb_mode = cdc
+
+
+# You an use this environment to send via OTA ; or, as an alternative, use the following command-line:
+# `pio run -e heltec_wifi_lora_32_V4 -t upload --upload-port=192.168.1.184`
+#
+[env:heltec_wifi_lora_32_V4-OTA]
+extends = env:heltec_wifi_lora_32_V4
 upload_protocol = espota
 upload_port = 192.168.1.184
 upload_flags = "--host_port=3232"

--- a/variants/heltec_V4/pins_arduino.h
+++ b/variants/heltec_V4/pins_arduino.h
@@ -1,0 +1,73 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define DISPLAY_HEIGHT 64
+#define DISPLAY_WIDTH  128
+
+#define USB_VID 0x303a
+#define USB_PID 0x1001
+
+static const uint8_t LED_BUILTIN = 35;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+#define LED_BUILTIN LED_BUILTIN  // allow testing #ifdef LED_BUILTIN
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+static const uint8_t SDA = 3;
+static const uint8_t SCL = 4;
+
+static const uint8_t SS    = 8;
+static const uint8_t MOSI  = 10;
+static const uint8_t MISO  = 11;
+static const uint8_t SCK   = 9;
+
+static const uint8_t A0 = 1;
+static const uint8_t A1 = 2;
+static const uint8_t A2 = 3;
+static const uint8_t A3 = 4;
+static const uint8_t A4 = 5;
+static const uint8_t A5 = 6;
+static const uint8_t A6 = 7;
+static const uint8_t A7 = 8;
+static const uint8_t A8 = 9;
+static const uint8_t A9 = 10;
+static const uint8_t A10 = 11;
+static const uint8_t A11 = 12;
+static const uint8_t A12 = 13;
+static const uint8_t A13 = 14;
+static const uint8_t A14 = 15;
+static const uint8_t A15 = 16;
+static const uint8_t A16 = 17;
+static const uint8_t A17 = 18;
+static const uint8_t A18 = 19;
+static const uint8_t A19 = 20;
+
+static const uint8_t T1 = 1;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 3;
+static const uint8_t T4 = 4;
+static const uint8_t T5 = 5;
+static const uint8_t T6 = 6;
+static const uint8_t T7 = 7;
+static const uint8_t T8 = 8;
+static const uint8_t T9 = 9;
+static const uint8_t T10 = 10;
+static const uint8_t T11 = 11;
+static const uint8_t T12 = 12;
+static const uint8_t T13 = 13;
+static const uint8_t T14 = 14;
+
+static const uint8_t Vext = 36;
+static const uint8_t LED  = 35;
+static const uint8_t RST_OLED = 21;
+static const uint8_t SCL_OLED = 18;
+static const uint8_t SDA_OLED = 17;
+
+static const uint8_t RST_LoRa = 12;
+static const uint8_t BUSY_LoRa = 13;
+static const uint8_t DIO0 = 14;
+
+#endif /* Pins_Arduino_h */


### PR DESCRIPTION
I have an Heltec WiFi LoRa 32 V4 board which is quite similar to V3 but has a [slightly different HW](https://wiki.heltec.org/docs/devices/open-source-hardware/esp32-series/lora-32/wifi-lora-32-v4/#hardware-version-comparison):
* 16MB (external) flash
* native USB, no more serial port
* 2MB PSRAM

I took the opportunity to slightly rearrange the PIO configuration in order to have a common part and different boards ; the default still being v3.