### PR TITLE
rename NetworkManager to prevent conflict with recent version of arduino-esp32

### DIFF
--- a/src/App.h
+++ b/src/App.h
@@ -5,7 +5,7 @@
 #include "MQTT/MqttManager.h"
 #include "MQTT/MqttDevice.h"
 #include "Config.h"
-#include "NetworkManager.h"
+#include "MyNetworkManager.h"
 #include "Portal.h"
 #include "Logs.h"
 #include "OTA.h"
@@ -25,7 +25,7 @@ private:
   Config _cfg;
   WiFiClient _wifiClient;
   MqttManager _mqtt;
-  NetworkManager _networkManager;
+  MyNetworkManager _networkManager;
   OTA _ota;
 
   FrisquetManager _frisquetManager;

--- a/src/Config.h
+++ b/src/Config.h
@@ -1,13 +1,13 @@
 #pragma once
 #include <heltec.h>
 #include <Preferences.h>
-#include "NetworkManager.h"
+#include "MyNetworkManager.h"
 #include "MQTT/MqttManager.h"
 #include "Frisquet/NetworkID.h"
 
 class Config {
     private:
-        NetworkManager::Options _wifiOpts;
+        MyNetworkManager::Options _wifiOpts;
         MqttManager::Options _mqttOpts;
         NetworkID _networkId;
 
@@ -31,7 +31,7 @@ class Config {
         void load();
         void save();
 
-        NetworkManager::Options& getWiFiOptions() { return _wifiOpts; }
+        MyNetworkManager::Options& getWiFiOptions() { return _wifiOpts; }
         MqttManager::Options& getMQTTOptions() { return _mqttOpts; }
         NetworkID& getNetworkID() { return _networkId; }
         void setNetworkID(NetworkID networkId) { _networkId = networkId; }

--- a/src/MyNetworkManager.cpp
+++ b/src/MyNetworkManager.cpp
@@ -1,6 +1,6 @@
-#include "NetworkManager.h"
+#include "MyNetworkManager.h"
 
-void NetworkManager::begin(const Options& opts) {
+void MyNetworkManager::begin(const Options& opts) {
   _opts = opts;
 
   // Mode station only
@@ -25,7 +25,7 @@ void NetworkManager::begin(const Options& opts) {
   startConnect();
 }
 
-void NetworkManager::attachEvents() {
+void MyNetworkManager::attachEvents() {
   // Un seul callback global, on switch par type d’événement
   _evAny = WiFi.onEvent([this](WiFiEvent_t event, WiFiEventInfo_t info){
     switch (event) {
@@ -63,7 +63,7 @@ void NetworkManager::attachEvents() {
   });
 }
 
-void NetworkManager::startConnect() {
+void MyNetworkManager::startConnect() {
   if (_opts.ssid.isEmpty()) return;
 
   // Petite protection : si déjà connecté, ne rien faire
@@ -82,7 +82,7 @@ void NetworkManager::startConnect() {
   }
 }
 
-void NetworkManager::scheduleReconnect() {
+void MyNetworkManager::scheduleReconnect() {
   // Couper proprement avant tentative
   WiFi.disconnect(true, false);
 
@@ -94,7 +94,7 @@ void NetworkManager::scheduleReconnect() {
   if (_failCount < 10) _failCount++;
 }
 
-uint32_t NetworkManager::computeBackoffMs() const {
+uint32_t MyNetworkManager::computeBackoffMs() const {
   // backoff = min(max, min * 2^failCount) + jitter(0..1s)
   uint32_t base = _opts.reconnectMinMs;
   uint32_t cap  = _opts.reconnectMaxMs;
@@ -106,7 +106,7 @@ uint32_t NetworkManager::computeBackoffMs() const {
   return backoff + jitter;
 }
 
-void NetworkManager::loop() {
+void MyNetworkManager::loop() {
   // Si connecté, rien à faire ici
   if (WiFi.isConnected()) return;
 
@@ -123,7 +123,7 @@ void NetworkManager::loop() {
   }
 }
 
-void NetworkManager::requestReconnectNow() {
+void MyNetworkManager::requestReconnectNow() {
   // Force la re-tentative immédiate
   WiFi.disconnect(true, false);
   _tNextAttempt = 0;
@@ -132,7 +132,7 @@ void NetworkManager::requestReconnectNow() {
   startConnect();
 }
 
-String NetworkManager::reasonToString(uint8_t reason) {
+String MyNetworkManager::reasonToString(uint8_t reason) {
   // Principaux codes (esp_wifi_types.h)
   switch (reason) {
     case WIFI_REASON_UNSPECIFIED: return "unspecified";

--- a/src/MyNetworkManager.h
+++ b/src/MyNetworkManager.h
@@ -3,7 +3,7 @@
 #include <WiFi.h>
 #include "Logs.h"
 
-class NetworkManager {
+class MyNetworkManager {
 public:
   struct Options {
     // Identification & accès
@@ -29,7 +29,7 @@ public:
     bool wifiSleep = false;
   };
 
-  NetworkManager() = default;
+  MyNetworkManager() = default;
 
   void begin(const Options& opts);
   void loop();


### PR DESCRIPTION
Starting with release 3.0.0 of arduino-esp32, two new files conflict with our own NetworkManager:
* libraries/Network/src/NetworkManager.h
* libraries/Network/src/NetworkManager.cpp

See https://github.com/espressif/arduino-esp32/pull/8760

While the default configuration is to build with arduino-esp32 2.0.17, it's better to be prevent a compilation error with newer releases of arduino-esp32.